### PR TITLE
feat: fix zeebe.client.broker.gateway-address property name

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 # Configuration for running connectors locally in bundle with connector-runtime
 server.port=9898
-zeebe.broker.gateway-address=localhost:26500
+zeebe.client.broker.gateway-address=localhost:26500
 zeebe.client.security.plaintext=true
 camunda.connector.polling.enabled=false


### PR DESCRIPTION
## Description

zeebe.client.broker.gateway-address property was malformed had to be corrected.

## Related issues
closes #
https://github.com/camunda/connector-template-outbound/issues/79

