### PR TITLE
chore: bump connector-runtime to 0.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
         <!-- connector SDK version -->
         <version.connector-core>0.11.4</version.connector-core>
-        <version.connector-runtime>0.21.4</version.connector-runtime>
+        <version.connector-runtime>0.22.0</version.connector-runtime>
 
         <!-- external libraries -->
         <version.assertj>3.24.2</version.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- connector SDK version -->
-        <version.connector-core>0.11.4</version.connector-core>
+        <version.connector-core>0.22.0</version.connector-core>
         <version.connector-runtime>0.22.0</version.connector-runtime>
 
         <!-- external libraries -->
@@ -55,6 +55,13 @@
         </dependency>
 
         <!-- test dependencies -->
+        <dependency>
+            <groupId>io.camunda.connector</groupId>
+            <artifactId>connector-test</artifactId>
+            <version>${version.connector-core}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/src/test/java/io/camunda/example/MyRequestTest.java
+++ b/src/test/java/io/camunda/example/MyRequestTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.connector.impl.ConnectorInputException;
+import io.camunda.connector.api.error.ConnectorInputException;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import io.camunda.example.dto.Authentication;
 import io.camunda.example.dto.MyConnectorRequest;


### PR DESCRIPTION
## Description

New version was released, so have to adjust version.

## Related issues

https://github.com/camunda/team-connectors/issues/475 

closes #

