### PR TITLE
chore: bump connector-runtime to 8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- connector SDK version -->
-    <version.connectors>0.23.1</version.connectors>
+    <version.connectors>8.3.0</version.connectors>
 
     <!-- external libraries -->
     <version.assertj>3.24.2</version.assertj>


### PR DESCRIPTION
## Description

Update connectors SDK version

## Related issues
https://github.com/camunda/team-connectors/issues/509

closes #

